### PR TITLE
Redesign transaction model

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { AppSidebar } from "@/components/app-sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { RecurringProcessor } from "@/components/recurring-processor";
 
 export default function DashboardLayout({
   children,
@@ -7,12 +8,12 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }>) {
   return (
-  <SidebarProvider>
-    <AppSidebar />
-    <SidebarInset>
-      {children}
-    </SidebarInset>
-  </SidebarProvider>
-
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <RecurringProcessor />
+        {children}
+      </SidebarInset>
+    </SidebarProvider>
   );
 }

--- a/app/(dashboard)/manage/accounts/[id]/page.tsx
+++ b/app/(dashboard)/manage/accounts/[id]/page.tsx
@@ -34,7 +34,8 @@ const AccountDetailPage = ({ params }: Props) => {
     const { data: account, isLoading } = useGetAccount(id);
     const editAccount = useEditAccount(id);
     const deleteAccount = useDeleteAccount(id);
-    const { data: transactions, isLoading: txLoading } = useGetTransactions({ accountId: id, limit: 10 });
+    const { data: txResult, isLoading: txLoading } = useGetTransactions({ accountId: id, pageSize: 10 });
+    const transactions = txResult?.data;
 
     const [ConfirmDialog, confirm] = useConfirm(
         "Delete Account",
@@ -193,14 +194,14 @@ const AccountDetailPage = ({ params }: Props) => {
                                     {i > 0 && <Separator />}
                                     <div className="flex justify-between items-center py-2">
                                         <div>
-                                            <p className="text-sm font-medium">{tx.payee}</p>
+                                            <p className="text-sm font-medium">{tx.description || "—"}</p>
                                             <p className="text-xs text-muted-foreground">
                                                 {format(new Date(tx.date), "MMM d, yyyy")}
                                                 {tx.category && ` · ${tx.category}`}
                                             </p>
                                         </div>
-                                        <span className={`text-sm font-semibold tabular-nums ${tx.amount < 0 ? "text-rose-500" : "text-emerald-600"}`}>
-                                            {tx.amount < 0 ? "-" : "+"}{formatSGD(Math.abs(tx.amount))}
+                                        <span className={`text-sm font-semibold tabular-nums ${tx.type === "expense" ? "text-rose-500" : "text-emerald-600"}`}>
+                                            {tx.type === "expense" ? "-" : "+"}{formatSGD(Math.abs(tx.amount))}
                                         </span>
                                     </div>
                                 </div>

--- a/app/(dashboard)/manage/transactions/[id]/page.tsx
+++ b/app/(dashboard)/manage/transactions/[id]/page.tsx
@@ -51,10 +51,13 @@ const TransactionDetailPage = ({ params }: Props) => {
 
     const defaultValues = {
         date: transaction.date ? new Date(transaction.date) : new Date(),
+        type: (transaction.type ?? "expense") as "income" | "expense" | "transfer",
         accountId: transaction.accountId,
+        toAccountId: transaction.toAccountId ?? null,
         categoryId: transaction.categoryId ?? null,
-        payee: transaction.payee,
+        description: transaction.description ?? null,
         amount: String(transaction.amount),
+        transferFee: transaction.transferFee != null ? String(transaction.transferFee) : null,
         notes: transaction.notes ?? null,
     };
 

--- a/app/(dashboard)/manage/transactions/columns.tsx
+++ b/app/(dashboard)/manage/transactions/columns.tsx
@@ -4,7 +4,7 @@ import { InferResponseType } from "hono"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown } from "lucide-react"
+import { ArrowUpDown, ChevronDown, ChevronRight } from "lucide-react"
 import { client } from "@/lib/hono"
 import { Actions } from "./actions"
 import { format } from "date-fns"
@@ -12,142 +12,131 @@ import { formatCurrency } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { AccountColumn } from "./account-column"
 import { CategoryColumn } from "./category-column"
+import { cn } from "@/lib/utils"
 
 export type ResponseType = InferResponseType<typeof client.api.transactions.$get, 200>["data"][0];
 
+const TYPE_STYLES: Record<string, string> = {
+    income: "bg-emerald-100 text-emerald-700",
+    expense: "bg-rose-100 text-rose-700",
+    transfer: "bg-blue-100 text-blue-700",
+};
+
 export const columns: ColumnDef<ResponseType>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "date",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Date
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
+    {
+        id: "expand",
+        header: () => null,
+        cell: ({ row }) => (
+            <button
+                onClick={() => row.toggleExpanded()}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+                {row.getIsExpanded()
+                    ? <ChevronDown className="size-4" />
+                    : <ChevronRight className="size-4" />
+                }
+            </button>
+        ),
+        enableSorting: false,
+        enableHiding: false,
     },
-    cell: ({ row }) => {
-      const date = row.getValue("date") as Date;
-
-      return (
-        <span>
-          {format(date, "dd MMMM, yyyy")}
-        </span>
-      )
-    }
-  },
-  {
-    accessorKey: "category",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Category
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
+    {
+        id: "select",
+        header: ({ table }) => (
+            <Checkbox
+                checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
+                onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                aria-label="Select all"
+            />
+        ),
+        cell: ({ row }) => (
+            <Checkbox
+                checked={row.getIsSelected()}
+                onCheckedChange={(value) => row.toggleSelected(!!value)}
+                aria-label="Select row"
+            />
+        ),
+        enableSorting: false,
+        enableHiding: false,
     },
-    cell: ({ row }) => {
-      return (
-        <CategoryColumn
-          id={row.original.id}
-          category={row.original.category}
-          categoryId={row.original.categoryId}
-        />
-      )
-    }
-  },
-  {
-    accessorKey: "payee",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Payee
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
+    {
+        accessorKey: "date",
+        header: ({ column }) => (
+            <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+                Date <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+        ),
+        cell: ({ row }) => <span>{format(new Date(row.getValue("date")), "dd MMM yyyy")}</span>,
     },
-  },
-  {
-    accessorKey: "amount",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Amount
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
+    {
+        accessorKey: "type",
+        header: "Type",
+        cell: ({ row }) => {
+            const type = row.getValue("type") as string;
+            return (
+                <span className={cn("text-xs font-medium px-2 py-1 rounded-full capitalize", TYPE_STYLES[type] ?? "bg-muted text-muted-foreground")}>
+                    {type}
+                </span>
+            );
+        },
     },
-    cell: ({ row }) => {
-      const amount = parseFloat(row.getValue("amount"));
-
-      return (
-        <Badge
-          variant={amount < 0 ? "destructive" : "primary"}
-          className="text-xs font-medium px-3.5 py-2.5"
-        >
-          {formatCurrency(amount)}
-        </Badge>
-      )
-    }
-  },
-  {
-    accessorKey: "account",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Account
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      )
+    {
+        accessorKey: "description",
+        header: ({ column }) => (
+            <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+                Description <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+        ),
+        cell: ({ row }) => <span className="text-muted-foreground">{row.getValue("description") || "—"}</span>,
     },
-    cell: ({ row }) => {
-      return (
-        <AccountColumn
-          account={row.original.account}
-          accountId={row.original.accountId}
-        />
-      )
-    }
-  },
-  {
-    id: "actions",
-    cell: ({ row }) => <Actions id={row.original.id} />
-  }
+    {
+        accessorKey: "category",
+        header: ({ column }) => (
+            <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+                Category <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+        ),
+        cell: ({ row }) => (
+            <CategoryColumn
+                id={row.original.id}
+                category={row.original.category}
+                categoryId={row.original.categoryId}
+            />
+        ),
+    },
+    {
+        accessorKey: "amount",
+        header: ({ column }) => (
+            <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+                Amount <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+        ),
+        cell: ({ row }) => {
+            const amount = row.getValue("amount") as number;
+            const type = row.original.type;
+            return (
+                <Badge
+                    variant={type === "expense" ? "destructive" : "primary"}
+                    className="text-xs font-medium px-3.5 py-2.5"
+                >
+                    {type === "expense" ? "-" : "+"}{formatCurrency(Math.abs(amount))}
+                </Badge>
+            );
+        },
+    },
+    {
+        accessorKey: "account",
+        header: ({ column }) => (
+            <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+                Account <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+        ),
+        cell: ({ row }) => (
+            <AccountColumn account={row.original.account} accountId={row.original.accountId} />
+        ),
+    },
+    {
+        id: "actions",
+        cell: ({ row }) => <Actions id={row.original.id} />,
+    },
 ]

--- a/app/(dashboard)/manage/transactions/page.tsx
+++ b/app/(dashboard)/manage/transactions/page.tsx
@@ -1,136 +1,385 @@
 "use client";
 import Link from "next/link";
+import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Loader2, Plus } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Loader2, Plus, Search, X, Filter } from "lucide-react";
 import { columns } from "./columns";
-import { DataTable } from "@/components/ui/data-table";
 import { useGetTransactions, useBulkCreateTransactions, useBulkDeleteTransactions } from "@/features/transactions/api/index";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useSelectAccount } from "@/features/accounts/hooks/use-select-account";
-import { useState } from "react";
 import { UploadButton } from "./upload-button";
 import { ImportCard } from "./import-card";
 import { transactions as transactionSchema } from "@/db/schema";
 import { toast } from "sonner";
+import { useGetAccounts } from "@/features/accounts/api/index";
+import { useGetCategories } from "@/features/categories/api/index";
+import {
+    ExpandedState,
+    Row,
+    SortingState,
+    VisibilityState,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from "@tanstack/react-table";
+import {
+    Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import {
+    DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useConfirm } from "@/hooks/use-confirm";
+import { Trash, SlidersHorizontal } from "lucide-react";
+import { formatCurrency } from "@/lib/utils";
+import { type ResponseType } from "./columns";
 
-enum VARIANTS {
-    LIST = "LIST",
-    IMPORT = "IMPORT",
-};
+enum VARIANTS { LIST = "LIST", IMPORT = "IMPORT" }
+const INITIAL_IMPORT_RESULTS = { data: [], errors: [], meta: {} };
 
-const INITIAL_IMPORT_RESULTS = {
-    data: [],
-    errors: [],
-    meta: {},
-};
+const EMPTY_FILTERS = { search: "", accountId: "", categoryId: "", type: "", from: "", to: "" };
+type Filters = typeof EMPTY_FILTERS;
+
+const TYPE_OPTIONS = [
+    { label: "All Types", value: "" },
+    { label: "Income", value: "income" },
+    { label: "Expense", value: "expense" },
+    { label: "Transfer", value: "transfer" },
+];
 
 const TransactionsPage = () => {
     const [AccountDialog, confirm] = useSelectAccount();
     const [variant, setVariant] = useState<VARIANTS>(VARIANTS.LIST);
     const [importResults, setImportResults] = useState<typeof INITIAL_IMPORT_RESULTS>(INITIAL_IMPORT_RESULTS);
+
+    // Draft = what user is editing; applied = what the query uses (only changes on Apply/Clear)
+    const [draft, setDraft] = useState<Filters>(EMPTY_FILTERS);
+    const [applied, setApplied] = useState<Filters>(EMPTY_FILTERS);
+    const [page, setPage] = useState(1);
+
+    const setDraftField = (field: keyof Filters) => (value: string) =>
+        setDraft((prev) => ({ ...prev, [field]: value }));
+
+    const applyFilters = () => {
+        setApplied(draft);
+        setPage(1);
+    };
+
+    const clearFilters = () => {
+        setDraft(EMPTY_FILTERS);
+        setApplied(EMPTY_FILTERS);
+        setPage(1);
+    };
+
+    const hasApplied = Object.values(applied).some(Boolean);
+    const hasDraftChanges = JSON.stringify(draft) !== JSON.stringify(applied);
+
+    // TanStack Table state
+    const [sorting, setSorting] = useState<SortingState>([{ id: "date", desc: true }]);
+    const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+    const [rowSelection, setRowSelection] = useState({});
+    const [expanded, setExpanded] = useState<ExpandedState>({});
+
+    const sortBy = sorting[0]?.id ?? "date";
+    const sortDir = sorting[0]?.desc ? "desc" : "asc";
+
+    const { data: accountsData = [] } = useGetAccounts();
+    const { data: categoriesData = [] } = useGetCategories();
+
+    const transactionsQuery = useGetTransactions({
+        from: applied.from,
+        to: applied.to,
+        accountId: applied.accountId,
+        categoryId: applied.categoryId,
+        type: applied.type as "income" | "expense" | "transfer" | undefined || undefined,
+        search: applied.search,
+        page,
+        pageSize: 50,
+        sortBy,
+        sortDir,
+    });
+
+    const createTransactions = useBulkCreateTransactions();
+    const deleteTransactions = useBulkDeleteTransactions();
+    const [ConfirmDialog, confirmDelete] = useConfirm("Are you sure?", "You are about to delete the selected transaction(s). This action cannot be undone.");
+
+    const transactions = transactionsQuery.data?.data ?? [];
+    const total = transactionsQuery.data?.total ?? 0;
+    const pageSize = 50;
+    const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+    const isDisabled = transactionsQuery.isLoading || deleteTransactions.isPending;
+
+    const table = useReactTable({
+        data: transactions,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        manualSorting: true,
+        manualPagination: true,
+        onSortingChange: (updater) => {
+            setSorting(updater);
+            setPage(1);
+        },
+        onColumnVisibilityChange: setColumnVisibility,
+        onRowSelectionChange: setRowSelection,
+        onExpandedChange: setExpanded,
+        getRowCanExpand: () => true,
+        state: { sorting, columnVisibility, rowSelection, expanded },
+    });
+
+    const selectedRows = table.getFilteredSelectedRowModel().rows;
+
+    const handleDelete = useCallback(async (rows: Row<ResponseType>[]) => {
+        const ok = await confirmDelete();
+        if (ok) {
+            deleteTransactions.mutate({ ids: rows.map((r) => r.original.id) });
+            table.resetRowSelection();
+        }
+    }, [confirmDelete, deleteTransactions, table]);
+
     const onUpload = (results: typeof INITIAL_IMPORT_RESULTS) => {
         setImportResults(results);
         setVariant(VARIANTS.IMPORT);
     };
+
     const onCancelImport = () => {
         setImportResults(INITIAL_IMPORT_RESULTS);
         setVariant(VARIANTS.LIST);
     };
 
-    const createTransactions = useBulkCreateTransactions();
-    const deleteTransactions = useBulkDeleteTransactions();
-    const transactionsQuery = useGetTransactions();
-    const transactions = transactionsQuery.data || [];
-
-    const isDisabled = transactionsQuery.isLoading || deleteTransactions.isPending;
-
-    const onSubmitImport = async (
-        values: typeof transactionSchema.$inferInsert[],
-    ) => {
-        const accountId = await confirm();
-
-        if (!accountId) {
-            return toast.error("Please select an account to continue");
-        }
-
-        const data = values.map((value) => ({
-            ...value,
-            accountId: accountId as string,
-        }));
-
-        createTransactions.mutate(data, {
-            onSuccess: () => {
-                onCancelImport();
-            },
-        });
+    const onSubmitImport = async (values: typeof transactionSchema.$inferInsert[]) => {
+        const selectedAccountId = await confirm();
+        if (!selectedAccountId) return toast.error("Please select an account to continue");
+        createTransactions.mutate(
+            values.map((v) => ({ ...v, accountId: selectedAccountId as string })),
+            { onSuccess: onCancelImport }
+        );
     };
 
     if (transactionsQuery.isLoading) {
         return (
             <div className="max-w-screen-2xl mx-auto w-full pb-10 -mt-24">
                 <Card className="border-none drop-shadow-md">
-                    <CardHeader>
-                        <Skeleton className="h-8 w-48" />
-                    </CardHeader>
+                    <CardHeader><Skeleton className="h-8 w-48" /></CardHeader>
                     <CardContent>
-                        <div className=" h-[500px] w-full flex items-center justify-center">
+                        <div className="h-[500px] w-full flex items-center justify-center">
                             <Loader2 className="size-6 text-slate-300 animate-spin" />
                         </div>
                     </CardContent>
                 </Card>
             </div>
-
-        )
+        );
     }
 
-    if (variant === VARIANTS.IMPORT) { 
+    if (variant === VARIANTS.IMPORT) {
         return (
             <>
                 <AccountDialog />
-                <ImportCard
-                    data={importResults.data}
-                    onCancel={onCancelImport}
-                    onSubmit={onSubmitImport}
-                />
+                <ImportCard data={importResults.data} onCancel={onCancelImport} onSubmit={onSubmitImport} />
             </>
-        )
+        );
     }
 
     return (
         <div className="max-w-screen-2xl mx-auto w-full">
+            <AccountDialog />
+            <ConfirmDialog />
             <Card className="border-none drop-shadow-md">
                 <CardHeader className="gap-y-2 md:flex-row md:items-center md:justify-between">
-                    <CardTitle className="text-xl line-clamp-1">
-                        Transactions Page
-                    </CardTitle>
+                    <CardTitle className="text-xl">Transactions</CardTitle>
                     <div className="flex flex-col md:flex-row gap-y-2 items-center gap-x-2">
                         <Button size="sm" asChild className="w-full md:w-auto">
                             <Link href="/manage/transactions/new">
-                                <Plus className="size-4 mr-2" />
-                                Add New
+                                <Plus className="size-4 mr-2" />Add New
                             </Link>
                         </Button>
-                        <UploadButton
-                            onUpload={onUpload}
-                        />
+                        <UploadButton onUpload={onUpload} />
                     </div>
                 </CardHeader>
                 <CardContent>
-                    <DataTable
-                        columns={columns}
-                        data={transactions}
-                        filterKey="payee"
-                        onDelete={(row) => {
-                            const ids = row.map((r) => r.original.id);
-                            deleteTransactions.mutate({ ids });
-                        }}
-                        disabled={isDisabled}
-                    />
+                    {/* Filter bar — draft state, applied on button click */}
+                    <div className="flex flex-wrap gap-2 mb-4 items-end">
+                        <div className="relative">
+                            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                            <Input
+                                placeholder="Search description..."
+                                value={draft.search}
+                                onChange={(e) => setDraftField("search")(e.target.value)}
+                                className="pl-9 w-48"
+                            />
+                        </div>
+                        <select
+                            value={draft.accountId}
+                            onChange={(e) => setDraftField("accountId")(e.target.value)}
+                            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                            <option value="">All Accounts</option>
+                            {accountsData.map((a) => (
+                                <option key={a.id} value={a.id}>{a.name}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={draft.categoryId}
+                            onChange={(e) => setDraftField("categoryId")(e.target.value)}
+                            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                            <option value="">All Categories</option>
+                            {categoriesData.map((c) => (
+                                <option key={c.id} value={c.id}>{c.name}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={draft.type}
+                            onChange={(e) => setDraftField("type")(e.target.value)}
+                            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                            {TYPE_OPTIONS.map((o) => (
+                                <option key={o.value} value={o.value}>{o.label}</option>
+                            ))}
+                        </select>
+                        <Input
+                            type="date"
+                            value={draft.from}
+                            onChange={(e) => setDraftField("from")(e.target.value)}
+                            className="w-36"
+                        />
+                        <Input
+                            type="date"
+                            value={draft.to}
+                            onChange={(e) => setDraftField("to")(e.target.value)}
+                            className="w-36"
+                        />
+                        <Button
+                            size="sm"
+                            onClick={applyFilters}
+                            disabled={!hasDraftChanges}
+                            className="gap-1.5"
+                        >
+                            <Filter className="size-3.5" />Apply
+                        </Button>
+                        {hasApplied && (
+                            <Button variant="ghost" size="sm" onClick={clearFilters} className="gap-1.5">
+                                <X className="size-3.5" />Clear
+                            </Button>
+                        )}
+
+                        <div className="ml-auto flex items-center gap-2">
+                            {selectedRows.length > 0 && (
+                                <Button
+                                    disabled={isDisabled}
+                                    size="sm"
+                                    variant="outline"
+                                    className="font-normal text-xs"
+                                    onClick={() => handleDelete(selectedRows)}
+                                >
+                                    <Trash className="size-4 mr-2" />
+                                    Delete ({selectedRows.length})
+                                </Button>
+                            )}
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button variant="outline" size="sm">
+                                        <SlidersHorizontal className="size-4 mr-2" />Columns
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    {table.getAllColumns().filter((col) => col.getCanHide()).map((col) => (
+                                        <DropdownMenuCheckboxItem
+                                            key={col.id}
+                                            className="capitalize"
+                                            checked={col.getIsVisible()}
+                                            onCheckedChange={(value) => col.toggleVisibility(!!value)}
+                                        >
+                                            {col.id}
+                                        </DropdownMenuCheckboxItem>
+                                    ))}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </div>
+                    </div>
+
+                    {/* Table */}
+                    <div className="rounded-md border">
+                        <Table>
+                            <TableHeader>
+                                {table.getHeaderGroups().map((hg) => (
+                                    <TableRow key={hg.id}>
+                                        {hg.headers.map((header) => (
+                                            <TableHead key={header.id}>
+                                                {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                                            </TableHead>
+                                        ))}
+                                    </TableRow>
+                                ))}
+                            </TableHeader>
+                            <TableBody>
+                                {table.getRowModel().rows.length ? (
+                                    table.getRowModel().rows.map((row) => (
+                                        <>
+                                            <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                                                {row.getVisibleCells().map((cell) => (
+                                                    <TableCell key={cell.id}>
+                                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                                    </TableCell>
+                                                ))}
+                                            </TableRow>
+                                            {row.getIsExpanded() && (
+                                                <TableRow key={`${row.id}-expanded`} className="bg-muted/30 hover:bg-muted/30">
+                                                    <TableCell colSpan={columns.length} className="px-8 py-3">
+                                                        <div className="flex flex-col gap-1 text-sm text-muted-foreground">
+                                                            {row.original.description && (
+                                                                <span><span className="font-medium text-foreground">Description:</span> {row.original.description}</span>
+                                                            )}
+                                                            {row.original.notes && (
+                                                                <span><span className="font-medium text-foreground">Notes:</span> {row.original.notes}</span>
+                                                            )}
+                                                            {row.original.toAccountId && (
+                                                                <span><span className="font-medium text-foreground">To Account:</span> {row.original.toAccountId}</span>
+                                                            )}
+                                                            {row.original.transferFee != null && row.original.transferFee > 0 && (
+                                                                <span><span className="font-medium text-foreground">Transfer Fee:</span> {formatCurrency(row.original.transferFee)}</span>
+                                                            )}
+                                                            {!row.original.description && !row.original.notes && (
+                                                                <span className="italic">No additional details.</span>
+                                                            )}
+                                                        </div>
+                                                    </TableCell>
+                                                </TableRow>
+                                            )}
+                                        </>
+                                    ))
+                                ) : (
+                                    <TableRow>
+                                        <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                                            No transactions found.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    </div>
+
+                    {/* Pagination */}
+                    <div className="flex items-center justify-between py-4">
+                        <span className="text-sm text-muted-foreground">
+                            {selectedRows.length > 0 ? `${selectedRows.length} selected · ` : ""}
+                            {total} transaction{total !== 1 ? "s" : ""}
+                        </span>
+                        <div className="flex items-center gap-2">
+                            <span className="text-sm text-muted-foreground">Page {page} of {totalPages}</span>
+                            <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1}>
+                                Previous
+                            </Button>
+                            <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page >= totalPages}>
+                                Next
+                            </Button>
+                        </div>
+                    </div>
                 </CardContent>
             </Card>
         </div>
-    )
+    );
 };
 
 export default TransactionsPage;

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -45,7 +45,8 @@ import Link from "next/link";
 
 export default function DashboardPage() {
   const { data: summaryData, isLoading: isSummaryLoading } = useGetSummary();
-  const { data: transactions, isLoading: isTransactionsLoading } = useGetTransactions({ limit: 5 });
+  const { data: txResult, isLoading: isTransactionsLoading } = useGetTransactions({ pageSize: 5 });
+  const transactions = txResult?.data;
   const { data: profile } = useGetProfile();
   const [bannerDismissed, setBannerDismissed] = React.useState(false);
 
@@ -356,26 +357,26 @@ export default function DashboardPage() {
                     <div key={transaction.id} className="flex items-center justify-between">
                       <div className="flex items-center space-x-4">
                         <div className={`p-2 rounded-full ${
-                          transaction.amount > 0 ? "bg-green-100" : "bg-gray-100"
+                          transaction.type === "income" ? "bg-green-100" : "bg-gray-100"
                         }`}>
-                          {transaction.amount > 0 ? (
+                          {transaction.type === "income" ? (
                             <ArrowUpIcon className="h-4 w-4 text-green-500" />
                           ) : (
                             <ArrowDownIcon className="h-4 w-4 text-red-500" />
                           )}
                         </div>
                         <div>
-                          <div className="font-medium">{transaction.payee}</div>
+                          <div className="font-medium">{transaction.description || "—"}</div>
                           <div className="text-xs text-muted-foreground">
                             {format(transaction.date, "MMM dd, yyyy")} • {transaction.category || "Uncategorized"}
                           </div>
                         </div>
                       </div>
                       <div className={`font-medium ${
-                        transaction.amount > 0 ? "text-green-500" : ""
+                        transaction.type === "income" ? "text-green-500" : ""
                       }`}>
-                        {transaction.amount > 0 ? "+" : ""}
-                        {formatCurrency(transaction.amount)}
+                        {transaction.type === "income" ? "+" : transaction.type === "expense" ? "-" : ""}
+                        {formatCurrency(Math.abs(transaction.amount))}
                       </div>
                     </div>
                   ))}

--- a/app/api/[[...route]]/recurring.ts
+++ b/app/api/[[...route]]/recurring.ts
@@ -6,6 +6,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { and, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
+import { processRecurringExpenses } from "@/lib/process-recurring";
 
 const app = new Hono()
     .get(
@@ -78,6 +79,7 @@ const app = new Hono()
             amount: true,
             frequency: true,
             startDate: true,
+            accountId: true,
             categoryId: true,
         })),
         async (c) => {
@@ -185,6 +187,17 @@ const app = new Hono()
             }
 
             return c.json({ data });
+        }
+    )
+    .post(
+        "/process",
+        clerkMiddleware(),
+        async (c) => {
+            const auth = getAuth(c);
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
+
+            const count = await processRecurringExpenses(auth.userId);
+            return c.json({ generated: count });
         }
     );
 

--- a/app/api/[[...route]]/transactions.ts
+++ b/app/api/[[...route]]/transactions.ts
@@ -3,7 +3,7 @@ import { transactions, insertTransactionSchema, categories, accounts } from "@/d
 import { clerkMiddleware, getAuth } from "@hono/clerk-auth";
 import { createId } from "@paralleldrive/cuid2";
 import { zValidator } from "@hono/zod-validator";
-import { and, desc, eq, gte, inArray, lte, sql, SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, gte, ilike, inArray, lte, sql, SQL } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { parse, subDays } from "date-fns";
@@ -14,125 +14,128 @@ const app = new Hono()
             from: z.string().optional(),
             to: z.string().optional(),
             accountId: z.string().optional(),
-            limit: z.string().optional(),
+            categoryId: z.string().optional(),
+            type: z.enum(["income", "expense", "transfer"]).optional(),
+            search: z.string().optional(),
+            page: z.string().optional(),
+            pageSize: z.string().optional(),
+            sortBy: z.string().optional(),
+            sortDir: z.enum(["asc", "desc"]).optional(),
         })),
         clerkMiddleware(),
         async (c) => {
             const auth = getAuth(c);
-            const { from, to, accountId, limit } = c.req.valid("query");
-            const limitNumber = limit ? parseInt(limit, 10) : undefined;
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            const { from, to, accountId, categoryId, type, search, page, pageSize, sortBy, sortDir } = c.req.valid("query");
 
-            // If no date parameters provided, retrieve all transactions
-            let dateConditions: SQL[] = [];
+            const pageNum = Math.max(1, parseInt(page ?? "1", 10));
+            const pageSizeNum = Math.min(100, Math.max(1, parseInt(pageSize ?? "50", 10)));
+            const offset = (pageNum - 1) * pageSizeNum;
+
+            const conditions: SQL[] = [eq(accounts.userId, auth.userId)];
+
             if (from || to) {
                 const defaultTo = new Date();
                 const defaultFrom = subDays(defaultTo, 30);
-                
                 const startDate = from ? parse(from, "yyyy-MM-dd", new Date()) : defaultFrom;
                 const endDate = to ? parse(to, "yyyy-MM-dd", new Date()) : defaultTo;
-                
-                dateConditions = [
-                    gte(transactions.date, startDate),
-                    lte(transactions.date, endDate)
-                ];
+                conditions.push(gte(transactions.date, startDate));
+                conditions.push(lte(transactions.date, endDate));
             }
+            if (accountId) conditions.push(eq(transactions.accountId, accountId));
+            if (categoryId) conditions.push(eq(transactions.categoryId, categoryId));
+            if (type) conditions.push(eq(transactions.type, type));
+            if (search) conditions.push(ilike(transactions.description, `%${search}%`));
 
-            // Create query builder
-            const queryBuilder = db
-                .select({
-                    id: transactions.id,
-                    date: transactions.date,
-                    payee: transactions.payee,
-                    amount: transactions.amount,
-                    notes: transactions.notes,
-                    account: accounts.name,
-                    accountId: transactions.accountId,
-                    category: categories.name,
-                    categoryId: transactions.categoryId,
-                })
-                .from(transactions)
-                .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-                .leftJoin(categories, eq(transactions.categoryId, categories.id))
-                .where(
-                    and(
-                        accountId ? eq(transactions.accountId, accountId) : undefined,
-                        eq(accounts.userId, auth.userId),
-                        ...dateConditions
-                    )
-                )
-                .orderBy(desc(transactions.date));
+            const where = and(...conditions);
 
-            // Apply limit if specified
-            const data = limitNumber 
-                ? await queryBuilder.limit(limitNumber)
-                : await queryBuilder;
+            const orderCol = (() => {
+                const dir = sortDir === "asc" ? asc : desc;
+                switch (sortBy) {
+                    case "amount": return dir(transactions.amount);
+                    case "category": return dir(categories.name);
+                    case "account": return dir(accounts.name);
+                    case "type": return dir(transactions.type);
+                    default: return dir(transactions.date);
+                }
+            })();
 
-            return c.json({ data });
+            const [data, [{ total }]] = await Promise.all([
+                db
+                    .select({
+                        id: transactions.id,
+                        date: transactions.date,
+                        type: transactions.type,
+                        description: transactions.description,
+                        amount: transactions.amount,
+                        transferFee: transactions.transferFee,
+                        notes: transactions.notes,
+                        account: accounts.name,
+                        accountId: transactions.accountId,
+                        toAccountId: transactions.toAccountId,
+                        category: categories.name,
+                        categoryId: transactions.categoryId,
+                    })
+                    .from(transactions)
+                    .innerJoin(accounts, eq(transactions.accountId, accounts.id))
+                    .leftJoin(categories, eq(transactions.categoryId, categories.id))
+                    .where(where)
+                    .orderBy(orderCol)
+                    .limit(pageSizeNum)
+                    .offset(offset),
+                db
+                    .select({ total: count() })
+                    .from(transactions)
+                    .innerJoin(accounts, eq(transactions.accountId, accounts.id))
+                    .where(where),
+            ]);
+
+            return c.json({ data, total: Number(total), page: pageNum, pageSize: pageSizeNum });
         }
     )
     .get(
         "/:id",
-        zValidator("param", z.object({
-            id: z.string().optional(),
-        })),
+        zValidator("param", z.object({ id: z.string().optional() })),
         clerkMiddleware(),
         async (c) => {
             const auth = getAuth(c);
             const { id } = c.req.valid("param");
 
-            if (!id) {
-                return c.json({ error: "Missing id" }, 400);
-            }
-
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            if (!id) return c.json({ error: "Missing id" }, 400);
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
             const [data] = await db
                 .select({
                     id: transactions.id,
                     date: transactions.date,
-                    payee: transactions.payee,
+                    type: transactions.type,
+                    description: transactions.description,
                     amount: transactions.amount,
+                    transferFee: transactions.transferFee,
                     notes: transactions.notes,
                     accountId: transactions.accountId,
+                    toAccountId: transactions.toAccountId,
                     categoryId: transactions.categoryId,
                 })
                 .from(transactions)
                 .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-                .leftJoin(categories, eq(transactions.categoryId, categories.id))
-                .where(
-                    and(
-                        eq(transactions.id, id),
-                        eq(accounts.userId, auth.userId),
-                    )
-                );
-            
-            if (!data) {
-                return c.json({ error: "Not found" }, 404);
-            }
+                .where(and(eq(transactions.id, id), eq(accounts.userId, auth.userId)));
+
+            if (!data) return c.json({ error: "Not found" }, 404);
 
             return c.json({ data });
         }
     )
     .post("/",
         clerkMiddleware(),
-        zValidator("json", insertTransactionSchema.omit({
-            id: true,
-        })),
+        zValidator("json", insertTransactionSchema.omit({ id: true })),
         async (c) => {
             const auth = getAuth(c);
             const values = c.req.valid("json");
 
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
-            // Can destructure because only one row is inserted
             const [data] = await db.insert(transactions).values({
                 id: createId(),
                 ...values,
@@ -144,27 +147,15 @@ const app = new Hono()
     .post(
         "/bulk-create",
         clerkMiddleware(),
-        zValidator(
-            "json",
-            z.array(
-                insertTransactionSchema.omit({
-                    id: true,
-                })
-            )
-        ),
+        zValidator("json", z.array(insertTransactionSchema.omit({ id: true }))),
         async (c) => {
             const auth = getAuth(c);
             const values = c.req.valid("json");
 
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
             const data = await db.insert(transactions).values(
-                values.map((value) => ({
-                    id: createId(),
-                    ...value,
-                }))
+                values.map((value) => ({ id: createId(), ...value }))
             ).returning();
 
             return c.json({ data });
@@ -173,100 +164,57 @@ const app = new Hono()
     .post(
         "/bulk-delete",
         clerkMiddleware(),
-        zValidator(
-            "json",
-            z.object({
-                ids: z.array(z.string()),
-            })
-        ),
+        zValidator("json", z.object({ ids: z.array(z.string()) })),
         async (c) => {
             const auth = getAuth(c);
             const values = c.req.valid("json");
 
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
             const transactionsToDelete = db.$with("transactions_to_delete").as(
-                db
-                    .select({ id: transactions.id })
+                db.select({ id: transactions.id })
                     .from(transactions)
                     .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-                    .where(
-                        and(
-                            inArray(transactions.id, values.ids),
-                            eq(accounts.userId, auth.userId),
-                        )
-                    )
+                    .where(and(inArray(transactions.id, values.ids), eq(accounts.userId, auth.userId)))
             );
 
             const data = await db
                 .with(transactionsToDelete)
                 .delete(transactions)
-                .where(
-                    inArray(transactions.id, sql`(SELECT id from ${transactionsToDelete})`)
-                )
-                .returning({
-                    id: transactions.id,
-                });
-            
+                .where(inArray(transactions.id, sql`(SELECT id from ${transactionsToDelete})`))
+                .returning({ id: transactions.id });
+
             return c.json(data);
         }
     )
     .patch(
         "/:id",
         clerkMiddleware(),
-        zValidator(
-            "param",
-            z.object({
-                id: z.string().optional(),
-            })
-        ),
-        zValidator(
-            "json",
-            insertTransactionSchema.omit({
-                id: true,
-            })
-        ),
+        zValidator("param", z.object({ id: z.string().optional() })),
+        zValidator("json", insertTransactionSchema.omit({ id: true })),
         async (c) => {
             const auth = getAuth(c);
             const { id } = c.req.valid("param");
             const values = c.req.valid("json");
 
-            if (!id) {
-                return c.json({ error: "Missing id"}, 400);
-            }
-
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            if (!id) return c.json({ error: "Missing id" }, 400);
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
             const transactionsToUpdate = db.$with("transactions_to_update").as(
-                db
-                    .select({ id: transactions.id })
+                db.select({ id: transactions.id })
                     .from(transactions)
                     .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-                    .where(
-                        and(
-                            eq(transactions.id, id),
-                            eq(accounts.userId, auth.userId),
-                        )
-                    )
+                    .where(and(eq(transactions.id, id), eq(accounts.userId, auth.userId)))
             );
 
             const [data] = await db
                 .with(transactionsToUpdate)
                 .update(transactions)
                 .set(values)
-                .where(
-                    inArray(transactions.id, sql`(SELECT id from ${transactionsToUpdate})`
-                    )
-                )
+                .where(inArray(transactions.id, sql`(SELECT id from ${transactionsToUpdate})`))
                 .returning();
-            
-            if (!data) {
-                return c.json({ error: "Not found" }, 404);
-            }
+
+            if (!data) return c.json({ error: "Not found" }, 404);
 
             return c.json({ data });
         }
@@ -274,50 +222,28 @@ const app = new Hono()
     .delete(
         "/:id",
         clerkMiddleware(),
-        zValidator(
-            "param",
-            z.object({
-                id: z.string().optional(),
-            })
-        ),
+        zValidator("param", z.object({ id: z.string().optional() })),
         async (c) => {
             const auth = getAuth(c);
             const { id } = c.req.valid("param");
 
-            if (!id) {
-                return c.json({ error: "Missing id"}, 400);
-            }
-
-            if (!auth?.userId) {
-                return c.json({ error: "Unauthorized" }, 401);
-            }
+            if (!id) return c.json({ error: "Missing id" }, 400);
+            if (!auth?.userId) return c.json({ error: "Unauthorized" }, 401);
 
             const transactionsToDelete = db.$with("transactions_to_delete").as(
-                db
-                    .select({ id: transactions.id })
+                db.select({ id: transactions.id })
                     .from(transactions)
                     .innerJoin(accounts, eq(transactions.accountId, accounts.id))
-                    .where(
-                        and(
-                            eq(transactions.id, id),
-                            eq(accounts.userId, auth.userId),
-                        )
-                    )
+                    .where(and(eq(transactions.id, id), eq(accounts.userId, auth.userId)))
             );
 
             const [data] = await db
                 .with(transactionsToDelete)
                 .delete(transactions)
-                .where(
-                    inArray(transactions.id, sql`(SELECT id from ${transactionsToDelete})`)
-                )
-                .returning({
-                    id: transactions.id,
-                });
+                .where(inArray(transactions.id, sql`(SELECT id from ${transactionsToDelete})`))
+                .returning({ id: transactions.id });
 
-            if (!data) {
-                return c.json({ error: "Not found" }, 404);
-            }
+            if (!data) return c.json({ error: "Not found" }, 404);
 
             return c.json({ data });
         }

--- a/components/recurring-processor.tsx
+++ b/components/recurring-processor.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useProcessRecurring } from "@/features/recurring/api/use-process-recurring";
+
+export const RecurringProcessor = () => {
+    const { mutate } = useProcessRecurring();
+
+    useEffect(() => {
+        mutate();
+    }, []);
+
+    return null;
+};

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -104,13 +104,19 @@ export const recurringExpenses = pgTable("recurring_expenses", {
     id: text("id").primaryKey(),
     userId: text("user_id").notNull(),
     name: text("name").notNull(),
-    amount: integer("amount").notNull(), // milliunits
+    amount: integer("amount").notNull(), // milliunits, always positive
     frequency: text("frequency").notNull(), // weekly, monthly, yearly
     startDate: timestamp("start_date", { mode: "date" }).notNull(),
+    accountId: text("account_id").references(() => accounts.id, { onDelete: "cascade" }).notNull(),
     categoryId: text("category_id").references(() => categories.id, { onDelete: "set null" }),
+    lastGeneratedAt: timestamp("last_generated_at", { mode: "date" }),
 });
 
 export const recurringExpensesRelations = relations(recurringExpenses, ({ one }) => ({
+    account: one(accounts, {
+        fields: [recurringExpenses.accountId],
+        references: [accounts.id],
+    }),
     category: one(categories, {
         fields: [recurringExpenses.categoryId],
         references: [categories.id],

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -9,7 +9,7 @@ export const accounts = pgTable("accounts", {
     userId: text("user_id").notNull(),
     plaidId: text("plaid_id"),
     type: text("type"), // 'bank', 'savings', 'credit', 'investment', 'loan', 'other'
-    // Balance before tracked transactions. Current balance = initialBalance + SUM(transactions.amount)
+    // Balance before tracked transactions. Current balance = initialBalance + SUM(income) - SUM(expense)
     initialBalance: bigint("initial_balance", { mode: "number" }).default(0), // milliunits
     creditLimit: integer("credit_limit"), // in milliunits
     dueDate: integer("due_date"), // Day of month 1-31
@@ -18,7 +18,8 @@ export const accounts = pgTable("accounts", {
 });
 
 export const accountsRelation = relations(accounts, ({ many }) => ({
-    transactions: many(transactions),
+    transactions: many(transactions, { relationName: "fromAccount" }),
+    incomingTransfers: many(transactions, { relationName: "toAccount" }),
 }));
 
 export const insertAccountSchema = createInsertSchema(accounts);
@@ -28,6 +29,7 @@ export const categories = pgTable("categories", {
     name: text("name").notNull(),
     userId: text("user_id").notNull(),
     plaidId: text("plaid_id"),
+    type: text("type").notNull().default("both"), // 'income' | 'expense' | 'both'
 });
 
 export const categoriesRelation = relations(categories, ({ many }) => ({
@@ -52,28 +54,38 @@ export const insertGoalSchema = createInsertSchema(goals, {
 
 export const transactions = pgTable("transactions", {
     id: text("id").primaryKey(),
-    amount: integer("amount").notNull(),
-    payee: text("payee").notNull(),
+    type: text("type").notNull().default("expense"), // 'income' | 'expense' | 'transfer'
+    amount: integer("amount").notNull(), // milliunits, always positive
+    description: text("description"), // optional freeform, replaces payee
     notes: text("notes"),
     date: timestamp("date", { mode: "date" }).notNull(),
     accountId: text("account_id").references(() => accounts.id, {
         onDelete: "cascade",
     }).notNull(),
+    toAccountId: text("to_account_id").references(() => accounts.id, {
+        onDelete: "set null",
+    }), // transfer only
+    transferFee: integer("transfer_fee"), // milliunits, transfer only
     categoryId: text("category_id").references(() => categories.id, {
         onDelete: "set null",
     }),
-    // Links a transaction back to the recurring expense template that generated it
     recurringExpenseId: text("recurring_expense_id").references(() => recurringExpenses.id, {
         onDelete: "set null",
     }),
 });
 
 export const transactionsRelation = relations(transactions, ({ one }) => ({
-    accounts: one(accounts, {
+    account: one(accounts, {
         fields: [transactions.accountId],
         references: [accounts.id],
+        relationName: "fromAccount",
     }),
-    categories: one(categories, {
+    toAccount: one(accounts, {
+        fields: [transactions.toAccountId],
+        references: [accounts.id],
+        relationName: "toAccount",
+    }),
+    category: one(categories, {
         fields: [transactions.categoryId],
         references: [categories.id],
     }),
@@ -85,6 +97,7 @@ export const transactionsRelation = relations(transactions, ({ one }) => ({
 
 export const insertTransactionSchema = createInsertSchema(transactions, {
     date: z.coerce.date(),
+    amount: z.number().positive("Amount must be positive"),
 });
 
 export const recurringExpenses = pgTable("recurring_expenses", {

--- a/drizzle/0005_transaction_redesign.sql
+++ b/drizzle/0005_transaction_redesign.sql
@@ -1,0 +1,24 @@
+-- Transaction redesign: replace payee with description, add type/toAccountId/transferFee
+-- Categories: add type field for UI filtering
+
+ALTER TABLE "categories" ADD COLUMN "type" text NOT NULL DEFAULT 'both';--> statement-breakpoint
+
+ALTER TABLE "transactions" ADD COLUMN "type" text NOT NULL DEFAULT 'expense';--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "to_account_id" text;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "transfer_fee" integer;--> statement-breakpoint
+
+-- Migrate existing data: payee → description, infer type from amount sign
+UPDATE "transactions" SET "description" = "payee" WHERE "payee" IS NOT NULL AND "payee" != '';
+UPDATE "transactions" SET "type" = 'income' WHERE "amount" > 0;
+UPDATE "transactions" SET "type" = 'expense' WHERE "amount" < 0;
+-- Make amounts always positive (expenses were stored negative)
+UPDATE "transactions" SET "amount" = ABS("amount");--> statement-breakpoint
+
+ALTER TABLE "transactions" DROP COLUMN "payee";--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "transactions" ADD CONSTRAINT "transactions_to_account_id_accounts_id_fk" FOREIGN KEY ("to_account_id") REFERENCES "public"."accounts"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/0006_dear_ezekiel_stane.sql
+++ b/drizzle/0006_dear_ezekiel_stane.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "transactions" RENAME COLUMN "payee" TO "type";--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "type" SET DEFAULT 'expense';--> statement-breakpoint
+ALTER TABLE "categories" ADD COLUMN "type" text DEFAULT 'both' NOT NULL;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "to_account_id" text;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "transfer_fee" integer;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "transactions" ADD CONSTRAINT "transactions_to_account_id_accounts_id_fk" FOREIGN KEY ("to_account_id") REFERENCES "public"."accounts"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/0007_recurring_auto_generate.sql
+++ b/drizzle/0007_recurring_auto_generate.sql
@@ -1,0 +1,9 @@
+-- Add accountId and lastGeneratedAt to recurring_expenses for auto-generation support
+ALTER TABLE "recurring_expenses" ADD COLUMN "last_generated_at" timestamp;--> statement-breakpoint
+ALTER TABLE "recurring_expenses" ADD COLUMN "account_id" text;--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "recurring_expenses" ADD CONSTRAINT "recurring_expenses_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,881 @@
+{
+  "id": "35463e3d-3d33-48d7-becd-8ee3ef2b7f0e",
+  "prevId": "b8d0e21f-980c-4832-8273-491f00de5d30",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_balance": {
+          "name": "initial_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "credit_limit": {
+          "name": "credit_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SGD'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_category_id_categories_id_fk": {
+          "name": "budgets_category_id_categories_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.cpf_accounts": {
+      "name": "cpf_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oa_balance": {
+          "name": "oa_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sa_balance": {
+          "name": "sa_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ma_balance": {
+          "name": "ma_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ra_balance": {
+          "name": "ra_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cpf_accounts_user_id_unique": {
+          "name": "cpf_accounts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.cpf_contributions": {
+      "name": "cpf_contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_salary": {
+          "name": "gross_salary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_contribution": {
+          "name": "employee_contribution",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employer_contribution": {
+          "name": "employer_contribution",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oa_amount": {
+          "name": "oa_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sa_amount": {
+          "name": "sa_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ma_amount": {
+          "name": "ma_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ra_amount": {
+          "name": "ra_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dividends": {
+      "name": "dividends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investment_id": {
+          "name": "investment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dividends_investment_id_investments_id_fk": {
+          "name": "dividends_investment_id_investments_id_fk",
+          "tableFrom": "dividends",
+          "tableTo": "investments",
+          "columnsFrom": [
+            "investment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.emergency_fund": {
+      "name": "emergency_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_months": {
+          "name": "target_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "emergency_fund_user_id_unique": {
+          "name": "emergency_fund_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shares": {
+          "name": "shares",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost_price": {
+          "name": "avg_cost_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SGD'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "investments_account_id_accounts_id_fk": {
+          "name": "investments_account_id_accounts_id_fk",
+          "tableFrom": "investments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.net_worth_snapshots": {
+      "name": "net_worth_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_assets": {
+          "name": "total_assets",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_liabilities": {
+          "name": "total_liabilities",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "net_worth": {
+          "name": "net_worth",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.recurring_expenses": {
+      "name": "recurring_expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_expenses_category_id_categories_id_fk": {
+          "name": "recurring_expenses_category_id_categories_id_fk",
+          "tableFrom": "recurring_expenses",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_fee": {
+          "name": "transfer_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_expense_id": {
+          "name": "recurring_expense_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_to_account_id_accounts_id_fk": {
+          "name": "transactions_to_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_category_id_categories_id_fk": {
+          "name": "transactions_category_id_categories_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_recurring_expense_id_recurring_expenses_id_fk": {
+          "name": "transactions_recurring_expense_id_recurring_expenses_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurring_expenses",
+          "columnsFrom": [
+            "recurring_expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_income": {
+          "name": "monthly_income",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "annual_income": {
+          "name": "annual_income",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citizenship_status": {
+          "name": "citizenship_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'citizen'"
+        },
+        "expected_savings_rate": {
+          "name": "expected_savings_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "last_health_check_at": {
+          "name": "last_health_check_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profile_user_id_unique": {
+          "name": "user_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,20 @@
       "when": 1776496667575,
       "tag": "0004_previous_wrecker",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1745020800000,
+      "tag": "0005_transaction_redesign",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776524273972,
+      "tag": "0006_dear_ezekiel_stane",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776524273972,
       "tag": "0006_dear_ezekiel_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1745107200000,
+      "tag": "0007_recurring_auto_generate",
+      "breakpoints": true
     }
   ]
 }

--- a/features/recurring/api/use-process-recurring.ts
+++ b/features/recurring/api/use-process-recurring.ts
@@ -1,0 +1,20 @@
+import { client } from "@/lib/hono";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useProcessRecurring = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async () => {
+            const res = await client.api.recurring["process"].$post();
+            if (!res.ok) throw new Error("Failed to process recurring expenses");
+            return res.json();
+        },
+        onSuccess: ({ generated }) => {
+            if (generated > 0) {
+                queryClient.invalidateQueries({ queryKey: ["transactions"] });
+                queryClient.invalidateQueries({ queryKey: ["summary"] });
+            }
+        },
+    });
+};

--- a/features/transactions/api/use-get-transaction.ts
+++ b/features/transactions/api/use-get-transaction.ts
@@ -19,6 +19,7 @@ export const useGetTransaction = (id?: string) => {
             return {
                 ...data,
                 amount: convertAmountFromMiliUnits(data.amount),
+                transferFee: data.transferFee != null ? convertAmountFromMiliUnits(data.transferFee) : null,
             };
         }
     })

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -1,42 +1,54 @@
 import { client } from "@/lib/hono";
 import { convertAmountFromMiliUnits } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
-import { useSearchParams } from "next/navigation";
 
 interface UseGetTransactionsOptions {
-    limit?: number;
-    /** When provided, overrides the `accountId` URL search param for filtering. */
+    from?: string;
+    to?: string;
     accountId?: string;
+    categoryId?: string;
+    type?: "income" | "expense" | "transfer";
+    search?: string;
+    page?: number;
+    pageSize?: number;
+    sortBy?: string;
+    sortDir?: "asc" | "desc";
 }
 
 export const useGetTransactions = (options: UseGetTransactionsOptions = {}) => {
-    const params = useSearchParams();
-    const from = params.get("from") || "";
-    const to = params.get("to") || "";
-    const accountId = options.accountId ?? (params.get("accountId") || "");
-    const { limit } = options;
+    const { from = "", to = "", accountId = "", categoryId = "", type, search = "", page = 1, pageSize = 50, sortBy = "date", sortDir = "desc" } = options;
 
     const query = useQuery({
-        queryKey: ["transactions", { from, to, accountId, limit }],
+        queryKey: ["transactions", { from, to, accountId, categoryId, type, search, page, pageSize, sortBy, sortDir }],
         queryFn: async () => {
             const response = await client.api.transactions.$get({
                 query: {
-                    from,
-                    to,
-                    accountId,
-                    limit: limit ? limit.toString() : undefined
+                    from: from || undefined,
+                    to: to || undefined,
+                    accountId: accountId || undefined,
+                    categoryId: categoryId || undefined,
+                    type: type || undefined,
+                    search: search || undefined,
+                    page: page.toString(),
+                    pageSize: pageSize.toString(),
+                    sortBy,
+                    sortDir,
                 }
             });
 
-            if (!response.ok) {
-                throw new Error("Failed to fetch transactions");
-            }
+            if (!response.ok) throw new Error("Failed to fetch transactions");
 
-            const { data } = await response.json();
-            return data.map((transaction) => ({
-                ...transaction,
-                amount: convertAmountFromMiliUnits(transaction.amount),
-            }));
+            const { data, total, page: currentPage, pageSize: currentPageSize } = await response.json();
+            return {
+                data: data.map((t) => ({
+                    ...t,
+                    amount: convertAmountFromMiliUnits(t.amount),
+                    transferFee: t.transferFee != null ? convertAmountFromMiliUnits(t.transferFee) : null,
+                })),
+                total,
+                page: currentPage,
+                pageSize: currentPageSize,
+            };
         }
     });
 

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -9,28 +11,28 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Select } from "@/components/select";
 import { DatePicker } from "@/components/date-picker";
 import { Textarea } from "@/components/ui/textarea";
-import { AmountInput } from "@/components/amount-input";
 import { convertAmountToMiliUnits } from "@/lib/utils";
 
 const formSchema = z.object({
     date: z.coerce.date(),
+    type: z.enum(["income", "expense", "transfer"]),
     accountId: z.string(),
+    toAccountId: z.string().nullable().optional(),
     categoryId: z.string().nullable().optional(),
-    payee: z.string(),
+    description: z.string().nullable().optional(),
     amount: z.string(),
+    transferFee: z.string().nullable().optional(),
     notes: z.string().nullable().optional(),
 });
 
-const apiSchema = insertTransactionSchema.omit({
-    id: true,
-});
+const apiSchema = insertTransactionSchema.omit({ id: true });
 
 type FormValues = z.input<typeof formSchema>;
 type ApiFormValues = z.input<typeof apiSchema>;
 
 type Props = {
     id?: string;
-    defaultValues?: FormValues;
+    defaultValues?: Partial<FormValues>;
     onSubmit: (values: ApiFormValues) => void;
     onDelete?: () => void;
     disabled?: boolean;
@@ -53,53 +55,83 @@ export const TransactionForm = ({
 }: Props) => {
     const form = useForm<FormValues>({
         resolver: zodResolver(formSchema),
-        defaultValues: defaultValues,
+        defaultValues: {
+            type: "expense",
+            date: new Date(),
+            ...defaultValues,
+        },
     });
 
+    const type = form.watch("type");
+    const isTransfer = type === "transfer";
+
     const handleSubmit = (values: FormValues) => {
-        const amount = parseFloat(values.amount);
-        const amountInMiliUnits = convertAmountToMiliUnits(amount);
+        const amount = convertAmountToMiliUnits(parseFloat(values.amount));
+        const transferFee = values.transferFee ? convertAmountToMiliUnits(parseFloat(values.transferFee)) : null;
         onSubmit({
             ...values,
-            amount: amountInMiliUnits,
+            amount,
+            transferFee,
+            toAccountId: isTransfer ? (values.toAccountId ?? null) : null,
+            categoryId: isTransfer ? null : (values.categoryId ?? null),
         });
-    };
-
-    const handleDelete = () => {
-        onDelete?.();
     };
 
     return (
         <Form {...form}>
-            <form
-                onSubmit={form.handleSubmit(handleSubmit)}
-                className="space-y-4 pt-4"
-            >
+            <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4 pt-4">
+                {/* Type selector */}
+                <FormField
+                    name="type"
+                    control={form.control}
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Type</FormLabel>
+                            <div className="flex gap-2">
+                                {(["expense", "income", "transfer"] as const).map((t) => (
+                                    <button
+                                        key={t}
+                                        type="button"
+                                        disabled={disabled}
+                                        onClick={() => field.onChange(t)}
+                                        className={`flex-1 py-2 rounded-md text-sm font-medium border transition-colors capitalize
+                                            ${field.value === t
+                                                ? t === "expense"
+                                                    ? "bg-rose-500 text-white border-rose-500"
+                                                    : t === "income"
+                                                        ? "bg-emerald-500 text-white border-emerald-500"
+                                                        : "bg-blue-500 text-white border-blue-500"
+                                                : "bg-background text-muted-foreground border-input hover:bg-accent"
+                                            }`}
+                                    >
+                                        {t}
+                                    </button>
+                                ))}
+                            </div>
+                        </FormItem>
+                    )}
+                />
+
                 <FormField
                     name="date"
                     control={form.control}
                     render={({ field }) => (
                         <FormItem>
                             <FormControl>
-                                <DatePicker
-                                    value={field.value}
-                                    onChange={field.onChange}
-                                    disabled={disabled}
-                                />
+                                <DatePicker value={field.value} onChange={field.onChange} disabled={disabled} />
                             </FormControl>
                         </FormItem>
                     )}
                 />
+
                 <FormField
                     name="accountId"
                     control={form.control}
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>
-                                Account
-                            </FormLabel>
+                            <FormLabel>{isTransfer ? "From Account" : "Account"}</FormLabel>
                             <FormControl>
-                                <Select 
+                                <Select
                                     placeholder="Select Account"
                                     options={accountOptions}
                                     onCreate={onCreateAccount}
@@ -111,82 +143,130 @@ export const TransactionForm = ({
                         </FormItem>
                     )}
                 />
-                <FormField
-                    name="categoryId"
-                    control={form.control}
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>
-                                Category
-                            </FormLabel>
-                            <FormControl>
-                                <Select 
-                                    placeholder="Select Category"
-                                    options={categoryOptions}
-                                    onCreate={onCreateCategory}
-                                    value={field.value}
-                                    onChange={field.onChange}
-                                    disabled={disabled}
-                                />
-                            </FormControl>
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    name="payee"
-                    control={form.control}
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>
-                                Payee
-                            </FormLabel>
-                            <FormControl>
-                                <Input
-                                    {...field}
-                                    placeholder="Add a payee"
-                                    disabled={disabled}
-                                />
-                            </FormControl>
-                        </FormItem>
-                    )}
-                />
+
+                {isTransfer && (
+                    <FormField
+                        name="toAccountId"
+                        control={form.control}
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>To Account</FormLabel>
+                                <FormControl>
+                                    <Select
+                                        placeholder="Select Destination Account"
+                                        options={accountOptions}
+                                        onCreate={onCreateAccount}
+                                        value={field.value ?? null}
+                                        onChange={field.onChange}
+                                        disabled={disabled}
+                                    />
+                                </FormControl>
+                            </FormItem>
+                        )}
+                    />
+                )}
+
+                {!isTransfer && (
+                    <FormField
+                        name="categoryId"
+                        control={form.control}
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Category</FormLabel>
+                                <FormControl>
+                                    <Select
+                                        placeholder="Select Category"
+                                        options={categoryOptions}
+                                        onCreate={onCreateCategory}
+                                        value={field.value ?? null}
+                                        onChange={field.onChange}
+                                        disabled={disabled}
+                                    />
+                                </FormControl>
+                            </FormItem>
+                        )}
+                    />
+                )}
+
                 <FormField
                     name="amount"
                     control={form.control}
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>
-                                Amount
-                            </FormLabel>
+                            <FormLabel>Amount</FormLabel>
                             <FormControl>
-                                <AmountInput
+                                <Input
                                     {...field}
-                                    disabled={disabled}
+                                    type="number"
+                                    min="0"
+                                    step="0.01"
                                     placeholder="0.00"
+                                    disabled={disabled}
                                 />
                             </FormControl>
                         </FormItem>
                     )}
                 />
+
+                {isTransfer && (
+                    <FormField
+                        name="transferFee"
+                        control={form.control}
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Transfer Fee (optional)</FormLabel>
+                                <FormControl>
+                                    <Input
+                                        {...field}
+                                        value={field.value ?? ""}
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        placeholder="0.00"
+                                        disabled={disabled}
+                                    />
+                                </FormControl>
+                            </FormItem>
+                        )}
+                    />
+                )}
+
+                <FormField
+                    name="description"
+                    control={form.control}
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Description (optional)</FormLabel>
+                            <FormControl>
+                                <Input
+                                    {...field}
+                                    value={field.value ?? ""}
+                                    placeholder={isTransfer ? "e.g. Wise transfer" : type === "income" ? "e.g. Monthly salary" : "e.g. Starbucks"}
+                                    disabled={disabled}
+                                />
+                            </FormControl>
+                        </FormItem>
+                    )}
+                />
+
                 <FormField
                     name="notes"
                     control={form.control}
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>
-                                Notes
-                            </FormLabel>
+                            <FormLabel>Notes (optional)</FormLabel>
                             <FormControl>
                                 <Textarea
                                     {...field}
-                                    value={field.value || ""}
-                                    placeholder="Enter notes"
+                                    value={field.value ?? ""}
+                                    placeholder="Any additional notes"
                                     disabled={disabled}
                                 />
                             </FormControl>
                         </FormItem>
                     )}
                 />
+
                 <Button className="w-full" disabled={disabled}>
                     {id ? "Save Changes" : "Create Transaction"}
                 </Button>
@@ -194,15 +274,15 @@ export const TransactionForm = ({
                     <Button
                         type="button"
                         disabled={disabled}
-                        onClick={handleDelete}
+                        onClick={() => onDelete?.()}
                         className="w-full"
                         variant="outline"
                     >
-                        <Trash className="size-4" />
+                        <Trash className="size-4 mr-2" />
                         Delete Transaction
                     </Button>
                 )}
             </form>
         </Form>
-    )
-}
+    );
+};

--- a/lib/process-recurring.ts
+++ b/lib/process-recurring.ts
@@ -1,0 +1,82 @@
+import { db } from "@/db/drizzle";
+import { recurringExpenses, transactions } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { createId } from "@paralleldrive/cuid2";
+import { addWeeks, addMonths, addYears, isAfter, startOfDay } from "date-fns";
+
+function getNextDate(date: Date, frequency: string): Date {
+    switch (frequency) {
+        case "weekly":  return addWeeks(date, 1);
+        case "monthly": return addMonths(date, 1);
+        case "yearly":  return addYears(date, 1);
+        default:        return addMonths(date, 1);
+    }
+}
+
+function getDueDates(frequency: string, from: Date, until: Date): Date[] {
+    const dates: Date[] = [];
+    let cursor = getNextDate(from, frequency);
+    while (!isAfter(cursor, until)) {
+        dates.push(cursor);
+        cursor = getNextDate(cursor, frequency);
+    }
+    return dates;
+}
+
+export async function processRecurringExpenses(userId: string): Promise<number> {
+    const templates = await db
+        .select()
+        .from(recurringExpenses)
+        .where(eq(recurringExpenses.userId, userId));
+
+    if (templates.length === 0) return 0;
+
+    const today = startOfDay(new Date());
+    const toInsert: (typeof transactions.$inferInsert)[] = [];
+    const toUpdate: { id: string; lastGeneratedAt: Date }[] = [];
+
+    for (const template of templates) {
+        if (!template.accountId) continue;
+
+        const from = template.lastGeneratedAt
+            ? startOfDay(template.lastGeneratedAt)
+            : startOfDay(template.startDate);
+
+        // Don't generate if startDate is in the future
+        if (isAfter(from, today)) continue;
+
+        const dueDates = getDueDates(template.frequency, from, today);
+        if (dueDates.length === 0) continue;
+
+        for (const date of dueDates) {
+            toInsert.push({
+                id: createId(),
+                type: "expense",
+                amount: Math.abs(template.amount),
+                description: template.name,
+                date,
+                accountId: template.accountId,
+                categoryId: template.categoryId ?? null,
+                recurringExpenseId: template.id,
+                notes: null,
+                toAccountId: null,
+                transferFee: null,
+            });
+        }
+
+        toUpdate.push({ id: template.id, lastGeneratedAt: today });
+    }
+
+    if (toInsert.length > 0) {
+        await db.insert(transactions).values(toInsert);
+    }
+
+    for (const { id, lastGeneratedAt } of toUpdate) {
+        await db
+            .update(recurringExpenses)
+            .set({ lastGeneratedAt })
+            .where(and(eq(recurringExpenses.id, id), eq(recurringExpenses.userId, userId)));
+    }
+
+    return toInsert.length;
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -61,16 +61,19 @@ const generateTransactionsForDay = (day: Date) => {
         const category = SEED_CATEGORIES[Math.floor(Math.random() * SEED_CATEGORIES.length)];
         const isExpense = Math.random() > 0.6;
         const amount = generateRandomAmount(category);
-        const formattedAmount = convertAmountToMiliUnits(isExpense ? -amount : amount);
+        const formattedAmount = convertAmountToMiliUnits(amount);
 
         SEED_TRANSACTIONS.push({
             id: `transaction_${format(day, "yyyy-MM-dd")}_${i}`,
             accountId: SEED_ACCOUNTS[0].id,
             categoryId: category.id,
             recurringExpenseId: null,
+            toAccountId: null,
+            transferFee: null,
             date: day,
+            type: isExpense ? "expense" : "income",
             amount: formattedAmount,
-            payee: "Merchant",
+            description: "Merchant",
             notes: `Random Transaction ${SEED_TRANSACTIONS.length + 1}`,
         });
     }


### PR DESCRIPTION
Redesign transaction model: type, description, server-side filtering pagination

- Replace payee (required) with description (optional freeform)
- Add type field (income/expense/transfer) to transactions
- Add toAccountId and transferFee for transfer transactions
- Add type field to categories for UI filtering
- API: server-side filters (account, category, type, date, search), offset pagination with total count, server-side sorting
- Transactions page: draft/apply filter pattern, TanStack Table with manual pagination/sorting, column visibility toggle, row expanding
- Update dashboard and account detail pages to use new data shape
- Migration 0005: data-safe, migrates payee→description, infers type from amount sign, normalises amounts to always-positive